### PR TITLE
Fix for Docker install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,8 @@
 export PGUSER=postgres
 psql <<- SHELL
   CREATE USER docker;
-  CREATE DATABASE "AdventureWorks";
-  GRANT ALL PRIVILEGES ON DATABASE "AdventureWorks" TO docker;
+  CREATE DATABASE "Adventureworks";
+  GRANT ALL PRIVILEGES ON DATABASE "Adventureworks" TO docker;
 SHELL
-psql -d AdventureWorks < /data/install.sql
+cd /data
+psql -d Adventureworks < /data/install.sql


### PR DESCRIPTION
The `install.sh` refers to the database name as `AdventureWorks`
while the rest of the scripts use `Adventureworks` (probably OK).

A breaking issue is that the working directory is not set to `/data`
before running `install.sql` and therefore no `.csv` files are
found to load the constant data.