### PR TITLE
Add auth to Docker user in docker-compose.yaml and install.sh

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,5 +5,7 @@ services:
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
+      DOCKER_USER: docker
+      DOCKER_PASSWORD: docker
     ports:
       - '5432:5432'

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 export PGUSER=postgres
 psql <<- SHELL
-  CREATE USER docker;
+  CREATE USER docker WITH PASSWORD '$DOCKER_PASSWORD';
   CREATE DATABASE "Adventureworks";
   GRANT ALL PRIVILEGES ON DATABASE "Adventureworks" TO docker;
 SHELL


### PR DESCRIPTION
Attempting to connect with the [`docker` user](https://github.com/lorint/AdventureWorks-for-Postgres/blob/master/install.sh#L5) throws:

> The server requested password-based authentication, but no password was provided.

I've added a `WITH PASSWORD` statement to pull the `DOCKER_PASSWORD` environment variable form the compose file during creation of the user.